### PR TITLE
restProps

### DIFF
--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -21,6 +21,6 @@ $: $formSubmitted = submitted;
 $: $messageColor = color;
 </script>
 
-<form on:submit|preventDefault = {submitHandler} {...$$props}>
+<form on:submit|preventDefault = {submitHandler} {...$$restProps}>
 <slot></slot>
 </form>


### PR DESCRIPTION
Using $$restProps is important because it allows the component to pass down any unspecified props to its child components without triggering any warnings or errors. This is particularly useful when dealing with complex component hierarchies where props can be spread across multiple levels.